### PR TITLE
Migrate settings for pytest, coverage, and codespell from `setup.cfg` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,13 @@ include_trailing_comma = true
 force_alphabetical_sort_within_sections = true
 honor_noqa = true
 lines_between_types = 1
+
+[tool]
+[tool.pytest.ini_options]
+minversion = "5.1"
+testpaths = "\"plasmapy_sphinx\""
+norecursedirs = ["\"build\"", "\"docs/\""]
+doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS", "NUMBER"]
+addopts = ["--doctest-modules", "--doctest-continue-on-failure"]
+filterwarnings = ["ignore:.*Creating a LegacyVersion.*:DeprecationWarning"]
+looponfailroots = ["plasmapy_sphinx"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,6 @@ omit = ["ci-helpers/*", "*/tests/*"]
 [tool.coverage.report]
 exclude_lines = ["coverage: ignore", "ImportError", "ModuleNotFoundError"]
 
+[tool.codespell]
+skip = "*.png,*cache*,*egg*,.git,.hypothesis,.idea,.tox,_build,*charged_particle*.ipynb,venv"
+ignore-words-list = ["aci,", "afe,", "ba,", "circularly,", "ded,", "dne,", "ect,", "explin,", "fo,", "fof,", "hist,", "hve,", "gud,", "nd,", "noo,", "nwo,", "ot,", "recuse,", "ro,", "te,", "ue,", "ue,", "windo"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,11 @@ doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS", "NUMBER"]
 addopts = ["--doctest-modules", "--doctest-continue-on-failure"]
 filterwarnings = ["ignore:.*Creating a LegacyVersion.*:DeprecationWarning"]
 looponfailroots = ["plasmapy_sphinx"]
+
+[tool.coverage]
+[tool.coverage.run]
+omit = ["ci-helpers/*", "*/tests/*"]
+
+[tool.coverage.report]
+exclude_lines = ["coverage: ignore", "ImportError", "ModuleNotFoundError"]
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -236,30 +236,3 @@ per-file-ignores =
     # The decorators.py ignore is temporary pending #1057
     plasmapy/particles/decorators.py:SIM102
     plasmapy/particles/ionization_state_collection.py:SIM102
-
-[codespell]
-skip = *.png,*cache*,*egg*,.git,.hypothesis,.idea,.tox,_build,*charged_particle*.ipynb,venv
-ignore-words-list =
-    aci,
-    afe,
-    ba,
-    circularly,
-    ded,
-    dne,
-    ect,
-    explin,
-    fo,
-    fof,
-    hist,
-    hve,
-    gud,
-    nd,
-    noo,
-    nwo,
-    ot,
-    recuse,
-    ro,
-    te,
-    ue,
-    ue,
-    windo

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,20 +104,6 @@ source-dir = docs
 build-dir = docs/_build
 all_files = 1
 
-[tool:pytest]
-minversion = 5.1
-testpaths = "plasmapy_sphinx"
-norecursedirs = "build" "docs/"
-doctest_optionflags =
-    NORMALIZE_WHITESPACE
-    ELLIPSIS
-    NUMBER
-addopts = --doctest-modules --doctest-continue-on-failure
-filterwarnings =
-    ignore:.*Creating a LegacyVersion.*:DeprecationWarning
-looponfailroots =
-    plasmapy_sphinx
-
 [flake8]
 convention = numpy
 # Checks marked as TODO should be eventually enabled,

--- a/setup.cfg
+++ b/setup.cfg
@@ -237,17 +237,6 @@ per-file-ignores =
     plasmapy/particles/decorators.py:SIM102
     plasmapy/particles/ionization_state_collection.py:SIM102
 
-[coverage:run]
-omit =
-    ci-helpers/*
-    */tests/*
-
-[coverage:report]
-exclude_lines =
-    coverage: ignore
-    ImportError
-    ModuleNotFoundError
-
 [codespell]
 skip = *.png,*cache*,*egg*,.git,.hypothesis,.idea,.tox,_build,*charged_particle*.ipynb,venv
 ignore-words-list =


### PR DESCRIPTION
First of several PRs to switch from `setup.cfg` to `pyproject.toml`.

This was done with the help of `pyproject-migrator`.  
