### PR TITLE
Drop use of deprecated `pkg_resources`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ import os
 import sys
 
 from datetime import datetime
-from pkg_resources import parse_version
+from packaging.version import Version
 
 sys.path.insert(0, os.path.abspath(".."))
 sys.path.insert(0, os.path.abspath("."))
@@ -155,10 +155,12 @@ copyright = f"2022–{datetime.utcnow().year}, {author}"
 #        However, release needs to be a semantic style version number, so set
 #        the 'unknown' case to ''.
 release = "" if release == "unknown" else release
-pv = parse_version(release)
-release = pv.public
+revision = ""
+if release != "":
+    pv = Version(release)
+    release = pv.public
+    revision = "" if pv.local is None else pv.local[1:]
 version = ".".join(release.split(".")[:2])  # short X.Y version
-revision = pv.local[1:] if pv.local is not None else ""
 
 # This is added to the end of RST files — a good place to put substitutions to
 # be used globally.

--- a/plasmapy_sphinx/__init__.py
+++ b/plasmapy_sphinx/__init__.py
@@ -73,28 +73,26 @@ import sys
 if sys.version_info < (3, 6):  # coverage: ignore
     raise ImportError("plasmapy_sphinx does not support Python < 3.6")
 
-# Packages may add whatever they like to this file, but
-# should keep this content at the top.
-# ----------------------------------------------------------------------------
-import pkg_resources
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version, PackageNotFoundError
+else:
+    from importlib_metadata import version, PackageNotFoundError
 
 from plasmapy_sphinx import autodoc, automodsumm, directives, utils
 
 
 # define version
 try:
-    # this places a runtime dependency on setuptools
-    #
     # note: if there's any distribution metadata in your source files, then this
     #       will find a version based on those files.  Keep distribution metadata
     #       out of your repository unless you've intentionally installed the package
-    #       as editable (e.g. `pip install -e {plasmapy_directory_root}`),
+    #       as editable (e.g. `pip install -e {root_directory}`),
     #       but then __version__ will not be updated with each commit, it is
     #       frozen to the version at time of install.
     #
     #: `plasmapy_sphinx` version string
-    __version__ = pkg_resources.get_distribution("plasmapy_sphinx").version
-except pkg_resources.DistributionNotFound:
+    __version__ = version("plasmapy_sphinx")
+except PackageNotFoundError:
     # package is not installed
     fallback_version = "unknown"
     try:
@@ -124,4 +122,4 @@ except pkg_resources.DistributionNotFound:
         del warn
     del fallback_version, warn_add
 
-del pkg_resources, sys
+del sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 ]
 dependencies = [
   "docutils",
+  "importlib_metadata; python_version < '3.8'",
   "jinja2 != 3.1",
   "sphinx >= 4.4",
   "sphinx-gallery",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ tests = [
 ]
 docs = [
     "numpydoc",
+    "packaging",
     "pillow",
     "pygments >= 2.11.0",
     "sphinx-changelog",

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,6 +5,7 @@
 -r extras.txt
 -r install.txt
 numpydoc
+packaging
 pillow
 pygments >= 2.11.0
 sphinx-changelog

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -2,6 +2,7 @@
 # ought to mirror 'install_requires' under 'options' in setup.cfg
 -r build.txt
 docutils
+importlib_metadata; python_version < '3.8'
 jinja2 != 3.1
 sphinx >= 4.4
 sphinx-gallery


### PR DESCRIPTION
This PR replaces uses of the deprecated package `pkg_resources`

1. `pkg_resources.parse_version` -> `packaging.version.Version`
2. `pkg_resources.get_distribution` -> `importlib.metadata.version` (or `importlib_metadata.version` for py < 3.8)
3. `pkg_resources.DistributionNotFound` -> `importlib.metadata.PackageNotFound`

`importlib_metadata` is used for Python < 3.8