### PR TITLE
Add Dependency Breadcrumbs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,4 +21,4 @@ python:
   - method: pip
     path: .
     extra_requirements:
-      - docs
+    - docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,7 @@ sphinx:
 
 python:
   install:
-  - requirements: requirements/docs.txt
   - method: pip
     path: .
+    extra_requirements:
+      - docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,9 @@
 [build-system]
-requires = ["setuptools >= 41.2",
-            "setuptools_scm",
-            "wheel >= 0.29.0"]  # ought to mirror 'requirements/build.txt'
+requires = [  # ought to mirror 'requirements/build.txt'
+    "setuptools >= 41.2",
+    "setuptools_scm",
+    "wheel >= 0.29.0",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -31,7 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dependencies = [
+dependencies = [  # ought to mirror 'requirements/install.txt'
   "docutils",
   "importlib_metadata; python_version < '3.8'",
   "jinja2 != 3.1",
@@ -41,7 +43,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-tests = [
+tests = [  # ought to mirror 'requirements/tests.txt'
   "codespell",
   "dlint",
   "flake8",
@@ -59,7 +61,7 @@ tests = [
   "pytest-xdist",
   "tox",
 ]
-docs = [
+docs = [  # ought to mirror 'requirements/docs.txt'
     "numpydoc",
     "packaging",
     "pillow",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # all dependencies required to build, run, test, and document plasmapy_sphinx
 # * look to the specific requirements/*.txt for specific needs
-# * this will mimic `pip install plasmapy[developer]` (excluding plasmapy)
+#
 -r requirements/build.txt
 -r requirements/install.txt
 -r requirements/tests.txt
 -r requirements/docs.txt
--r requirements/extras.txt

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,5 +1,8 @@
-# these are dependencies required to build the package distribution for installation
-# ought to mirror 'build-system.requires' under in pyproject.toml
+# these are dependencies required to build the package distribution for
+# installation
+#
+# ought to mirror [build-system.requires] under in pyproject.toml
+#
 setuptools >= 41.2
 setuptools_scm
 wheel >= 0.29.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,8 +1,7 @@
-# These are dependencies required to build package documentation, and
-# ought to mirror 'docs' under options.extras_require in setup.cfg.
-# This lists the requirements that would be installed when doing:
-# pip install plasmapy[docs]
--r extras.txt
+# These are dependencies required to build package documentation
+#
+# ought to mirror [project.optional-dependencies.docs] in pyproject.toml
+#
 -r install.txt
 numpydoc
 packaging

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -1,7 +1,0 @@
-name: plasmapy
-
-dependencies:
-- python=3.10
-- pip
-- pip:
-  - -r ../requirements.txt

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,8 +1,0 @@
-# These are "extra" dependencies to run advanced package features, and
-# ought to mirror 'extras' under options.extras_require in setup.cfg.
-# This lists the requirements that would be installed when doing:
-# pip install plasmapy[extras]
--r install.txt
-codespell
-pre-commit
-tox

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,5 +1,7 @@
 # these are dependencies required to use the package
-# ought to mirror 'install_requires' under 'options' in setup.cfg
+#
+# ought to mirror [project.dependencies] in pyproject.toml
+#
 -r build.txt
 docutils
 importlib_metadata; python_version < '3.8'

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,9 +1,9 @@
-# These are dependencies required to run package tests, and
-# ought to mirror 'tests' under options.extras_require in setup.cfg.
-# This lists the requirements that would be installed when doing:
-# pip install plasmapy[tests]
--r extras.txt
+# These are dependencies required to run package tests
+#
+# ought to mirror [project.optional-dependencies.tests] in pyproject.toml
+#
 -r install.txt
+codespell
 dlint
 flake8
 flake8-absolute-import
@@ -13,7 +13,9 @@ flake8-rst-docstrings
 flake8-simplify
 flake8-use-fstring
 hypothesis
+pre-commit
 pydocstyle
 pytest >= 5.4.0
 pytest-regressions
 pytest-xdist
+tox


### PR DESCRIPTION
Add breadcrumb comments so if dependencies in `pyproject.toml` are modified, then the developer knows which requirement files (`requirements/*.txt`) need to also be updated, and vice-versa.

Update `.readthedocs.yml` such that dependencies are installed using `plasmapy_sphinx[docs]`.