### PR TITLE
"Modernize" GitHub Wrokflows

### DIFF
--- a/.github/workflows/check_install.yml
+++ b/.github/workflows/check_install.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.6', '3.10', '3.12', '3.13' ]
+        python: [ '3.8', '3.10', '3.12', '3.13' ]
         os: [ ubuntu-latest ]
 
     steps:

--- a/.github/workflows/check_install.yml
+++ b/.github/workflows/check_install.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions: {}
+permissions: {}  # disables all GitHub permissions for the workflow
 
 jobs:
   pip-install-and-import:

--- a/.github/workflows/check_install.yml
+++ b/.github/workflows/check_install.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 1
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
         cache: pip

--- a/.github/workflows/check_install.yml
+++ b/.github/workflows/check_install.yml
@@ -1,0 +1,40 @@
+name: Install and Import
+
+on:
+  push:
+    branches:
+    - main
+    - v0.*.x
+    tags:
+    - v*
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  pip-install-and-import:
+    name: Installation with pip & import (py-${{ matrix.python }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python: [ '3.6', '3.10', '3.12', '3.13' ]
+        os: [ ubuntu-latest ]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+        cache: 'pip'
+    - name: Install plasmapy_sphinx with pip
+      run: pip install .
+    - name: Import plasmapy_sphinx
+      run: python -c "import plasmapy_sphinx"

--- a/.github/workflows/check_install.yml
+++ b/.github/workflows/check_install.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.10', '3.12', '3.13' ]
+        python: [ '3.8', '3.10', '3.11', '3.12', '3.13' ]
         os: [ ubuntu-latest ]
 
     steps:

--- a/.github/workflows/check_install.yml
+++ b/.github/workflows/check_install.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.10', '3.11', '3.12', '3.13' ]
-        os: [ ubuntu-latest ]
+        python: ['3.8', '3.10', '3.11', '3.12', '3.13']
+        os: [ubuntu-latest]
 
     steps:
     - name: Checkout code
@@ -33,7 +33,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
-        cache: 'pip'
+        cache: pip
     - name: Install plasmapy_sphinx with pip
       run: pip install .
     - name: Import plasmapy_sphinx

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         fetch-depth: 1
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
         cache: pip
@@ -69,7 +69,7 @@ jobs:
       with:
         fetch-depth: 1
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
         cache: pip

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,19 +38,3 @@ jobs:
     - name: Build Docs
       run: |
         sphinx-build ./docs ./docs/_build -n --keep-going -W -b html -q
-
-  pip-install:
-    name: Installation with pip
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.12
-    - name: Install plasmapy_sphinx with pip
-      run: pip install .

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --progress-bar off --upgrade pip
-          python -m pip install --progress-bar off -r requirements/docs.txt sphinx ${{ matrix.sphinx }}
+          python -m pip install --progress-bar off -r requirements/docs.txt ${{ matrix.sphinx }}
           sudo apt-get install graphviz pandoc
       - name: Build Docs
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,4 +40,4 @@ jobs:
         sudo apt-get install graphviz pandoc
     - name: Build Docs
       run: |
-        sphinx-build ./docs ./docs/_build -n --keep-going -W -b html -q
+        sphinx-build ./docs ./docs/_build -n --keep-going -b html -q -v -v -v

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -41,3 +41,43 @@ jobs:
     - name: Build Docs
       run: |
         sphinx-build ./docs ./docs/_build -n --keep-going -b html -q
+
+  sphinx_limits:
+    name: Doc Build on Key Sphinx Restriction (${{ matrix.sphinx }})
+    runs-on:  ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python: [ '3.12' ]
+        os: [ ubuntu-latest ]
+
+        include:
+          - python: '3.12'
+            os: ubuntu-latest
+            sphinx: "<7.4"
+
+          - python: '3.12'
+            os: ubuntu-latest
+            sphinx: "<8.2"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --progress-bar off --upgrade pip
+          python -m pip install --progress-bar off -r requirements/docs.txt sphinx sphinx${{ matrix.sphinx }}
+          sudo apt-get install graphviz pandoc
+      - name: Build Docs
+        run: |
+          sphinx-build ./docs ./docs/_build -n --keep-going -b html -q
+
+        

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -76,6 +76,6 @@ jobs:
           sudo apt-get install graphviz pandoc
       - name: Build Docs
         run: |
-          sphinx-build ./docs ./docs/_build -n --keep-going -b html -q
+          sphinx-build ./docs ./docs/_build -n --keep-going -W -b html -q
 
         

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --progress-bar off --upgrade pip
-        python -m pip install --progress-bar off -r requirements/docs.txt git+https://github.com/PlasmaPy/plasmapy
+        python -m pip install --progress-bar off -r requirements/docs.txt
         sudo apt-get install graphviz pandoc
     - name: Build Docs
       run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -51,6 +51,10 @@ jobs:
 
       matrix:
         include:
+        - python: '3.11'
+          os: ubuntu-latest
+          sphinx: sphinx<7.2
+
         - python: '3.12'
           os: ubuntu-latest
           sphinx: sphinx<7.4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.10', '3.12', '3.13']
+        python: ['3.8', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --progress-bar off --upgrade pip
-          python -m pip install --progress-bar off -r requirements/docs.txt ${{ matrix.sphinx }}
+          python -m pip install --progress-bar off -r requirements/docs.txt "${{ matrix.sphinx }}"
           sudo apt-get install graphviz pandoc
       - name: Build Docs
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,11 +25,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --progress-bar off --upgrade pip

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.12']
+        python: ['3.6', '3.10', '3.12', '3.13']
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -43,23 +43,21 @@ jobs:
         sphinx-build ./docs ./docs/_build -n --keep-going -b html -q
 
   sphinx_limits:
-    name: Doc Build on Key Sphinx Restriction (${{ matrix.sphinx }})
+    name: Doc Build on ${{ matrix.sphinx }}
     runs-on:  ${{ matrix.os }}
 
     strategy:
       fail-fast: false
-      matrix:
-        python: [ '3.12' ]
-        os: [ ubuntu-latest ]
 
+      matrix:
         include:
           - python: '3.12'
             os: ubuntu-latest
-            sphinx: "<7.4"
+            sphinx: "sphinx<7.4"
 
           - python: '3.12'
             os: ubuntu-latest
-            sphinx: "<8.2"
+            sphinx: "sphinx<8.2"
 
     steps:
       - name: Checkout code
@@ -74,7 +72,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --progress-bar off --upgrade pip
-          python -m pip install --progress-bar off -r requirements/docs.txt sphinx sphinx${{ matrix.sphinx }}
+          python -m pip install --progress-bar off -r requirements/docs.txt sphinx ${{ matrix.sphinx }}
           sudo apt-get install graphviz pandoc
       - name: Build Docs
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -77,5 +77,3 @@ jobs:
       - name: Build Docs
         run: |
           sphinx-build ./docs ./docs/_build -n --keep-going -W -b html
-
-        

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,7 +40,7 @@ jobs:
         sudo apt-get install graphviz pandoc
     - name: Build Docs
       run: |
-        sphinx-build ./docs ./docs/_build -n --keep-going -W -b html -q
+        sphinx-build ./docs ./docs/_build -n --keep-going -W -b html
 
   sphinx_limits:
     name: Doc Build on ${{ matrix.sphinx }}
@@ -76,6 +76,6 @@ jobs:
           sudo apt-get install graphviz pandoc
       - name: Build Docs
         run: |
-          sphinx-build ./docs ./docs/_build -n --keep-going -W -b html -q
+          sphinx-build ./docs ./docs/_build -n --keep-going -W -b html
 
         

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,4 +40,4 @@ jobs:
         sudo apt-get install graphviz pandoc
     - name: Build Docs
       run: |
-        sphinx-build ./docs ./docs/_build -n --keep-going -b html -q -v -v -v
+        sphinx-build ./docs ./docs/_build -n --keep-going -b html -q

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,7 +40,7 @@ jobs:
         sudo apt-get install graphviz pandoc
     - name: Build Docs
       run: |
-        sphinx-build ./docs ./docs/_build -n --keep-going -b html -q
+        sphinx-build ./docs ./docs/_build -n --keep-going -W -b html -q
 
   sphinx_limits:
     name: Doc Build on ${{ matrix.sphinx }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
-        cache: 'pip'
+        cache: pip
     - name: Install dependencies
       run: |
         python -m pip install --progress-bar off --upgrade pip
@@ -44,36 +44,36 @@ jobs:
 
   sphinx_limits:
     name: Doc Build on ${{ matrix.sphinx }}
-    runs-on:  ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
 
       matrix:
         include:
-          - python: '3.12'
-            os: ubuntu-latest
-            sphinx: 'sphinx<7.4'
+        - python: '3.12'
+          os: ubuntu-latest
+          sphinx: sphinx<7.4
 
-          - python: '3.12'
-            os: ubuntu-latest
-            sphinx: 'sphinx<8.2'
+        - python: '3.12'
+          os: ubuntu-latest
+          sphinx: sphinx<8.2
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
-          cache: 'pip'
-      - name: Install dependencies
-        run: |
-          python -m pip install --progress-bar off --upgrade pip
-          python -m pip install --progress-bar off -r requirements/docs.txt "${{ matrix.sphinx }}"
-          sudo apt-get install graphviz pandoc
-      - name: Build Docs
-        run: |
-          sphinx-build ./docs ./docs/_build -n --keep-going -W -b html
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+        cache: pip
+    - name: Install dependencies
+      run: |
+        python -m pip install --progress-bar off --upgrade pip
+        python -m pip install --progress-bar off -r requirements/docs.txt "${{ matrix.sphinx }}"
+        sudo apt-get install graphviz pandoc
+    - name: Build Docs
+      run: |
+        sphinx-build ./docs ./docs/_build -n --keep-going -W -b html

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -53,11 +53,11 @@ jobs:
         include:
           - python: '3.12'
             os: ubuntu-latest
-            sphinx: "sphinx<7.4"
+            sphinx: 'sphinx<7.4'
 
           - python: '3.12'
             os: ubuntu-latest
-            sphinx: "sphinx<8.2"
+            sphinx: 'sphinx<8.2'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.10', '3.12', '3.13']
+        python: ['3.8', '3.10', '3.12', '3.13']
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}  # disables all GitHub permissions for the workflow
+
 jobs:
   documentation:
     name: Doc Build - py${{ matrix.python }} on ${{ matrix.os }}

--- a/.github/workflows/mint-release.yml
+++ b/.github/workflows/mint-release.yml
@@ -8,6 +8,8 @@ on:
         required: true
         default: 0.1.0rc1
 
+permissions: {}  # disables all GitHub permissions for the workflow
+
 jobs:
 
   tag:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -340,9 +340,8 @@ nitpick_ignore_regex = [
     (python_role, "plasmapy.particles.particle_collections"),
     (python_role, "plasmapy.utils.decorators.lite_func"),
     # Sphinx
-    (python_role, "sphinx.util.docutils.SphinxDirective.parse_inline"),
-    (python_role, "system_message"),
-    (python_role, "sphinx.ext.autodoc.ObjectMembers"),
+    (python_role, "system_message"),  # sphinx.util.docutils.system_message
+    (python_role, "ObjectMembers"),  # sphinx.ext.autodoc.ObjectMembers
 ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -341,6 +341,7 @@ nitpick_ignore_regex = [
     (python_role, "plasmapy.utils.decorators.lite_func"),
     # Sphinx
     (python_role, "sphinx.util.docutils.SphinxDirective.parse_inline"),
+    (python_role, "system_message"),
 ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -339,6 +339,8 @@ nitpick_ignore_regex = [
     (python_role, "plasmapy.analysis.swept_langmuir.find_floating_potential"),
     (python_role, "plasmapy.particles.particle_collections"),
     (python_role, "plasmapy.utils.decorators.lite_func"),
+    # Sphinx
+    (python_role, "sphinx.util.docutils.SphinxDirective.parse_inline"),
 ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -342,6 +342,7 @@ nitpick_ignore_regex = [
     # Sphinx
     (python_role, "sphinx.util.docutils.SphinxDirective.parse_inline"),
     (python_role, "system_message"),
+    (python_role, "sphinx.ext.autodoc.ObjectMembers"),
 ]
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -341,6 +341,7 @@ nitpick_ignore_regex = [
     (python_role, "plasmapy.utils.decorators.lite_func"),
     # Sphinx
     (python_role, "system_message"),  # sphinx.util.docutils.system_message
+    (python_role, "ObjectMember"),  # sphinx.ext.autodoc.ObjectMember
     (python_role, "ObjectMembers"),  # sphinx.ext.autodoc.ObjectMembers
 ]
 

--- a/plasmapy_sphinx/__init__.py
+++ b/plasmapy_sphinx/__init__.py
@@ -73,10 +73,7 @@ import sys
 if sys.version_info < (3, 8):  # coverage: ignore
     raise ImportError("plasmapy_sphinx does not support Python < 3.8")
 
-if sys.version_info >= (3, 8):
-    from importlib.metadata import version, PackageNotFoundError
-else:
-    from importlib_metadata import version, PackageNotFoundError
+from importlib.metadata import version, PackageNotFoundError
 
 from plasmapy_sphinx import autodoc, automodsumm, directives, utils
 

--- a/plasmapy_sphinx/__init__.py
+++ b/plasmapy_sphinx/__init__.py
@@ -70,8 +70,8 @@ __all__ = ["__version__"]
 # This is the same check as the one at the top of setup.py
 import sys
 
-if sys.version_info < (3, 6):  # coverage: ignore
-    raise ImportError("plasmapy_sphinx does not support Python < 3.6")
+if sys.version_info < (3, 8):  # coverage: ignore
+    raise ImportError("plasmapy_sphinx does not support Python < 3.8")
 
 if sys.version_info >= (3, 8):
     from importlib.metadata import version, PackageNotFoundError

--- a/plasmapy_sphinx/autodoc/automodapi.py
+++ b/plasmapy_sphinx/autodoc/automodapi.py
@@ -303,7 +303,6 @@ __all__ = ["AutomodapiOptions", "ModAPIDocumenter", "setup"]
 
 import inspect
 import re
-import sys
 import warnings
 
 from collections import OrderedDict

--- a/plasmapy_sphinx/autodoc/automodapi.py
+++ b/plasmapy_sphinx/autodoc/automodapi.py
@@ -308,7 +308,10 @@ import warnings
 from collections import OrderedDict
 from docutils.parsers.rst import directives
 from docutils.statemachine import StringList
+from packaging.version import Version
+from sphinx import __version__ as sphinx_version
 from sphinx.application import Sphinx
+from typing import Any
 
 try:
     from sphinx.deprecation import RemovedInSphinx50Warning
@@ -504,6 +507,15 @@ class ModAPIDocumenter(ModuleDocumenter):
             ],
         ),
     }
+
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+
+        if Version(sphinx_version) < Version("7.2") and "no-index" in self.options:
+            # sphinx started using :no-index: instead of the original :noindex:
+            # in version 7.2
+            opt_value = self.options.pop("no-index")
+            self.options["noindex"] = opt_value
 
     @property
     def grouping_info(self) -> Dict[str, Dict[str, Union[str, None]]]:

--- a/plasmapy_sphinx/autodoc/automodapi.py
+++ b/plasmapy_sphinx/autodoc/automodapi.py
@@ -348,6 +348,8 @@ _option_spec = {
     "inheritance-diagram": bool_option,
     "no-inheritance-diagram": bool_option,
 }  # type: Dict[str, Callable]
+if "no-index" not in _option_spec:
+    _option_spec["no-index"] = bool_option
 for option_name in list(_option_spec):
     if "member" in option_name:
         del _option_spec[option_name]

--- a/plasmapy_sphinx/autodoc/automodapi.py
+++ b/plasmapy_sphinx/autodoc/automodapi.py
@@ -311,7 +311,6 @@ from docutils.statemachine import StringList
 from packaging.version import Version
 from sphinx import __version__ as sphinx_version
 from sphinx.application import Sphinx
-from typing import Any
 
 try:
     from sphinx.deprecation import RemovedInSphinx50Warning

--- a/plasmapy_sphinx/automodsumm/core.py
+++ b/plasmapy_sphinx/automodsumm/core.py
@@ -664,7 +664,16 @@ class Automodsumm(Autosummary):
         self, name: str, prefixes: List[str]
     ) -> Tuple[str, Any, Any, str]:
         """See :func:`sphinx.ext.autosummary.import_by_name`"""
-        return super(Automodsumm, self).import_by_name(name, prefixes)
+
+        for prefix in prefixes:
+            if prefix is None:
+                continue
+
+            if name.startswith(f"{prefix}."):
+                name = name.removeprefix(f'{prefix}.')
+                break
+
+        return super().import_by_name(name, prefixes)
 
 
 def setup(app: "Sphinx"):

--- a/plasmapy_sphinx/automodsumm/core.py
+++ b/plasmapy_sphinx/automodsumm/core.py
@@ -208,6 +208,8 @@ __all__ = [
 import os
 
 from importlib import import_module
+from packaging.version import Version
+from sphinx import __version__ as sphinx_version
 from sphinx.ext.autosummary import Autosummary
 from sphinx.util import logging
 from typing import Any, Callable, Dict, List, Tuple, Union
@@ -304,6 +306,11 @@ class AutomodsummOptions:
             "rel_to_doc": None,
             "abspath": None,
         }  # type: Dict[str, Union[str, None]]
+
+        if Version(sphinx_version) < Version("7.2") and "no-index" in self._options:
+            # sphinx started using :no-index: instead of the original :noindex:
+            opt_value = self._options.pop("no-index")
+            self._options["noindex"] = opt_value
 
         self.condition_options()
 

--- a/plasmapy_sphinx/automodsumm/core.py
+++ b/plasmapy_sphinx/automodsumm/core.py
@@ -670,7 +670,7 @@ class Automodsumm(Autosummary):
                 continue
 
             if name.startswith(f"{prefix}."):
-                name = name.removeprefix(f'{prefix}.')
+                name = name[len(prefix):]
                 break
 
         return super().import_by_name(name, prefixes)

--- a/plasmapy_sphinx/automodsumm/core.py
+++ b/plasmapy_sphinx/automodsumm/core.py
@@ -670,7 +670,7 @@ class Automodsumm(Autosummary):
                 continue
 
             if name.startswith(f"{prefix}."):
-                name = name[len(prefix):]
+                name = name[len(prefix)+1:]
                 break
 
         return super().import_by_name(name, prefixes)

--- a/plasmapy_sphinx/automodsumm/core.py
+++ b/plasmapy_sphinx/automodsumm/core.py
@@ -307,11 +307,6 @@ class AutomodsummOptions:
             "abspath": None,
         }  # type: Dict[str, Union[str, None]]
 
-        if Version(sphinx_version) < Version("7.2") and "no-index" in self._options:
-            # sphinx started using :no-index: instead of the original :noindex:
-            opt_value = self._options.pop("no-index")
-            self._options["noindex"] = opt_value
-
         self.condition_options()
 
     @property

--- a/plasmapy_sphinx/automodsumm/generate.py
+++ b/plasmapy_sphinx/automodsumm/generate.py
@@ -322,6 +322,11 @@ class GenDocsFromAutomodsumm:
             }
             if Version(sphinx_version) < Version("8.2"):
                 _kwargs["app"] = app
+            else:
+                _kwargs["config"] = app.config
+                _kwargs["events"] = app.events
+                _kwargs["registry"] = app.registry
+
             content = generate_autosummary_content(**_kwargs)
 
             filename = os.path.join(path, filename_map.get(name, name) + suffix)

--- a/plasmapy_sphinx/automodsumm/generate.py
+++ b/plasmapy_sphinx/automodsumm/generate.py
@@ -8,6 +8,8 @@ import os
 import re
 
 from jinja2 import TemplateNotFound
+from packaging.version import Version
+from sphinx import __version__ as sphinx_version
 from sphinx.ext.autodoc.mock import mock
 from sphinx.ext.autosummary import get_rst_suffix, import_by_name, import_ivar_by_name
 from sphinx.ext.autosummary.generate import (
@@ -306,19 +308,21 @@ class GenDocsFromAutomodsumm:
             if app:
                 context.update(app.config.autosummary_context)
 
-            content = generate_autosummary_content(
-                name,
-                obj,
-                parent,
-                template,
-                entry.template,
-                imported_members,
-                app,
-                entry.recursive,
-                context,
-                modname,
-                qualname,
-            )
+            _kwargs = {
+                "name": name,
+                "obj": obj,
+                "parent": parent,
+                "template": template,
+                "template_name": entry.template,
+                "imported_members": imported_members,
+                "recursive": entry.recursive,
+                "context": context,
+                "modname": modname,
+                "qualname": qualname,
+            }
+            if Version(sphinx_version) < Version("8.2"):
+                _kwargs["app"] = app
+            content = generate_autosummary_content(**_kwargs)
 
             filename = os.path.join(path, filename_map.get(name, name) + suffix)
             if os.path.isfile(filename):

--- a/plasmapy_sphinx/automodsumm/generate.py
+++ b/plasmapy_sphinx/automodsumm/generate.py
@@ -27,7 +27,6 @@ from plasmapy_sphinx.utils import templates_dir
 if False:
     # for annotation, does not need real import
     from sphinx.application import Sphinx
-    from sphinx.builders import Builder
 
 
 logger = logging.getLogger(__name__)

--- a/plasmapy_sphinx/automodsumm/generate.py
+++ b/plasmapy_sphinx/automodsumm/generate.py
@@ -293,7 +293,7 @@ class GenDocsFromAutomodsumm:
             ensuredir(path)
 
             try:
-                name, obj, parent, modname = import_by_name(entry.name)
+                name, obj, parent, modname = import_by_name(entry.name, prefixes=(None,))
                 qualname = name.replace(modname + ".", "")
             except ImportError as e:
                 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [  # ought to mirror 'requirements/install.txt'
   "importlib_metadata; python_version < '3.8'",
   "jinja2 != 3.1",
   "packaging",
-  "sphinx >= 4.4, < 7.4",
+  "sphinx >= 4.4, < 8.2",
   "sphinx-gallery",
   "sphinx_rtd_theme >= 1.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [  # ought to mirror 'requirements/install.txt'
   "docutils",
   "importlib_metadata; python_version < '3.8'",
   "jinja2 != 3.1",
-  "sphinx >= 4.4",
+  "sphinx >= 4.4, < 8.2",
   "sphinx-gallery",
   "sphinx_rtd_theme >= 1.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ docs = [  # ought to mirror 'requirements/docs.txt'
     "numpydoc",
     "packaging",
     "pillow",
+    "plasmapy > 8.0",
     "pygments >= 2.11.0",
     "sphinx-changelog",
     "sphinx-copybutton",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [  # ought to mirror 'requirements/install.txt'
   "docutils",
   "importlib_metadata; python_version < '3.8'",
   "jinja2 != 3.1",
-  "sphinx >= 4.4, < 8.2",
+  "sphinx >= 4.4, < 7.4",
   "sphinx-gallery",
   "sphinx_rtd_theme >= 1.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [  # ought to mirror 'requirements/install.txt'
   "docutils",
   "importlib_metadata; python_version < '3.8'",
   "jinja2 != 3.1",
+  "packaging",
   "sphinx >= 4.4, < 7.4",
   "sphinx-gallery",
   "sphinx_rtd_theme >= 1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 ]
 description = "Sphinx extensions for the PlasmaPy Project"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 dynamic = ["version"]
 license = {file = "LICENSE.md"}
 keywords = ["plasmapy", "sphinx", "documentation"]
@@ -24,8 +24,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [  # ought to mirror 'requirements/install.txt'
   "importlib_metadata; python_version < '3.8'",
   "jinja2 != 3.1",
   "packaging",
-  "sphinx >= 4.4, < 8.2",
+  "sphinx >= 4.4",
   "sphinx-gallery",
   "sphinx_rtd_theme >= 1.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [  # ought to mirror 'requirements/build.txt'
-    "setuptools >= 41.2",
+    "setuptools >= 61",
     "setuptools_scm",
     "wheel >= 0.29.0",
 ]

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -3,6 +3,6 @@
 #
 # ought to mirror [build-system.requires] under in pyproject.toml
 #
-setuptools >= 41.2
+setuptools >= 61
 setuptools_scm
 wheel >= 0.29.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,6 +6,7 @@
 numpydoc
 packaging
 pillow
+plasmapy > 8.0
 pygments >= 2.11.0
 sphinx-changelog
 sphinx-copybutton

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -6,6 +6,6 @@
 docutils
 importlib_metadata; python_version < '3.8'
 jinja2 != 3.1
-sphinx >= 4.4, < 8.2
+sphinx >= 4.4, < 7.4
 sphinx-gallery
 sphinx_rtd_theme >= 1.0.0

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -6,6 +6,6 @@
 docutils
 importlib_metadata; python_version < '3.8'
 jinja2 != 3.1
-sphinx >= 4.4
+sphinx >= 4.4, < 8.2
 sphinx-gallery
 sphinx_rtd_theme >= 1.0.0

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -7,6 +7,6 @@ docutils
 importlib_metadata; python_version < '3.8'
 jinja2 != 3.1
 packaging
-sphinx >= 4.4, < 8.2
+sphinx >= 4.4
 sphinx-gallery
 sphinx_rtd_theme >= 1.0.0

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -7,6 +7,6 @@ docutils
 importlib_metadata; python_version < '3.8'
 jinja2 != 3.1
 packaging
-sphinx >= 4.4, < 7.4
+sphinx >= 4.4, < 8.2
 sphinx-gallery
 sphinx_rtd_theme >= 1.0.0

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -6,6 +6,7 @@
 docutils
 importlib_metadata; python_version < '3.8'
 jinja2 != 3.1
+packaging
 sphinx >= 4.4, < 7.4
 sphinx-gallery
 sphinx_rtd_theme >= 1.0.0


### PR DESCRIPTION
This PR updates the GitHub workflows associated with `plasmapy_sphinx`.  This was need due to infrequent updates to `plasmapy_sphinx` and changes made to `sphinx`.  What was done...

- min Python version was bumped from `3.6` to `3.8`
- added dependency `packaging`
- added dependency `plasmapy > 8.0`
- `check_install.yml` was created to test installing and importing `plasmapy_sphinx` on `ubuntu-latest` for python `3.8`, `3.10`, `3.11`, `3.12`, and `3.13`
- updated `documentation.yml` workflow `documentation` to test on python `3.8`, `3.10`, `3.11`, `3.12`, and `3.13`
- added to `documentation.yml` workflow `sphinx_limits` to test documentation building on `sphinx < 7.2`, `sphinx < 7.4` and `sphinx < 8.2`.  Changes in these `sphinx` version were not backwards compaitble.
  - `sphinx >= 8.2` broke functionality related to `generate_autosummary_content()`.  The change dropped argument `app` for required keywords `config`, `events`, and `registry`.  `plasmapy_sphinx` adopted a strategy to pass the expected arguments based on the installed `sphinx` version.
  - `sphinx >= 7.4` broke functionality related to `import_by_name()`.  The functionality changed how it was handling prefixes for the modules.  I updated `Automodsumm.import_by_name()` to automatically remove an items prefix from its name before calling `Autosummary.import_by_name()`.
  - `sphinx >= 7.2` refactored the `autodoc` option `:noindex` to `:no-index:`.  So our `automodapi` functionality can handle the more modern `:no-index:`, I updated `ModAPIDocumenter` to set the `:noindex:` option if `:no-index:` was given when using `sphinx < 7.2` to build.


> [!NOTE]
> This PR originated as PR #17, but that PR scope creeped.  Thus, the workflow functionality from #17 was broken out into this PR.