### PR TITLE
Fix invalid escape sequence error

### DIFF
--- a/plasmapy_sphinx/theme/__init__.py
+++ b/plasmapy_sphinx/theme/__init__.py
@@ -1,6 +1,6 @@
 # Sphinx Guide to Theme Development
 # https://www.sphinx-doc.org/en/master/development/theming.html
-"""
+r"""
 The PlasmaPy theme is a `Sphinx theme
 <https://www.sphinx-doc.org/en/master/usage/theming.html>`_ that
 inherits from the `sphinx_rtd_theme`.  As such, it shares all the same


### PR DESCRIPTION
I've been getting an invalid escape sequence error for the docstring of `plasmapy_sphinx/theme/__init__.py`.  This PR changes that docstring into a raw string.