### PR TITLE
Remove permission restrictions from workflow to mint a release

### DIFF
--- a/.github/workflows/mint-release.yml
+++ b/.github/workflows/mint-release.yml
@@ -8,8 +8,6 @@ on:
         required: true
         default: 0.1.0rc1
 
-permissions: {}  # disables all GitHub permissions for the workflow
-
 jobs:
 
   tag:


### PR DESCRIPTION
I just attempted the workflow to mint a release, and it failed. It looked like the failure reason what due to lack of permissions. This PR tentatively removes the line in `mint-release.yml` that restrictions workflow permissions.