### PR TITLE
Update for Sphinx v9 Compatibility

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.8', '3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        fetch-depth: 1
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        fetch-depth: 1
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -63,6 +63,10 @@ jobs:
           os: ubuntu-latest
           sphinx: sphinx<8.2
 
+        - python: '3.13'
+          os: ubuntu-latest
+          sphinx: sphinx<9.0
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/plasmapy_sphinx/automodsumm/core.py
+++ b/plasmapy_sphinx/automodsumm/core.py
@@ -623,7 +623,11 @@ class Automodsumm(Autosummary):
         return processor
 
     def get_items(self, names):
-        self.bridge.genopt["imported-members"] = True
+        if Version(sphinx_version) < Version("9.0"):
+            self.bridge.genopt["imported-members"] = True
+        else:
+            # sphinx dropped the use of DocumenterBridge in v9.0
+            self.options["imported-members"] = True
         return Autosummary.get_items(self, names)
 
     @property

--- a/plasmapy_sphinx/automodsumm/generate.py
+++ b/plasmapy_sphinx/automodsumm/generate.py
@@ -321,10 +321,13 @@ class GenDocsFromAutomodsumm:
             }
             if Version(sphinx_version) < Version("8.2"):
                 _kwargs["app"] = app
-            else:
+            elif Version(sphinx_version) < Version("9.0"):
                 _kwargs["config"] = app.config
                 _kwargs["events"] = app.events
                 _kwargs["registry"] = app.registry
+            else:
+                _kwargs["config"] = app.config
+                _kwargs["events"] = app.events
 
             content = generate_autosummary_content(**_kwargs)
 


### PR DESCRIPTION
This PR updates `plasmapy_sphinx` to provide compatibility with `sphinx>=9.

- Updated `Automodsumm.get_items()` to handle the removal of `DocumenterBridger` in `sphinx>=9`.  For Sphinx `v9` the `self.options` dictionary is used to override the the `"import-members"` directive option instead of `self.bridge.genopt`.
- `GenDocsFromAutomodsumm.generate_docs()` uses the `sphinx` function `generate_autosummary_content()`.  For Sphinx `v9` the keyword argument `"registry"` was dropped.  `generate_docs()` will pass kwargs based on what version of `sphinx` is installed.
- The Documentation test workflow was updated `documentaiton.yml`:
  - `fetch-depth` for `actions/checkout` was changed to `0` so `setuptools_scm` could properly build the `plasmapy_sphinx` package version.
  - Test on Python 3.14 was added.
  - Test on Python 3.13 and `sphinx<9` was added.

---

fixes #23 
fixes #24 