### PR TITLE
Add a dependabot configuration for the `github-actions` ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  cooldown:
+    default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 updates:
 - package-ecosystem: github-actions
-  directory: "/"
+  directory: /
   schedule:
-    interval: "monthly"
+    interval: monthly
   cooldown:
     default-days: 7


### PR DESCRIPTION
I added a basic `.github/dependabot.yml`, adapted from PlasmaPy's but with monthly updates instead of weekly. It includes a dependency cooldown period since this gives a chance for security vulnerabilities to be identified before we start using them.

Closes #27.